### PR TITLE
fix link to https://www.w3.org/TR/annotation-model/#h-fragment-selector 

### DIFF
--- a/sections/structure/rdfscontentreference.md
+++ b/sections/structure/rdfscontentreference.md
@@ -46,7 +46,7 @@ The class `iirds:Selector` references parts of files. The property `iirds:has-se
 * `iirds:RangeSelector`  
    Selects a part of a file by a start and an end identifier.
 
-To select parts of a file, an `iirds:Selector` <em title="MUST in RFC 2119 context" class="rfc2119">MUST</em> have an `rdf:value` and `dcterms:conformsTo`. The value <em title="MUST in RFC 2119 context" class="rfc2119">MUST</em> conform to the standard specified by the property `dcterms:conformsTo`. Only a standard from the following list of fragment selectors <em title="MUST in RFC 2119 context" class="rfc2119">MUST</em> be used: [https://www.w3.org/TR/annotation-model/#fragment-selector].
+To select parts of a file, an `iirds:Selector` <em title="MUST in RFC 2119 context" class="rfc2119">MUST</em> have an `rdf:value` and `dcterms:conformsTo`. The value <em title="MUST in RFC 2119 context" class="rfc2119">MUST</em> conform to the standard specified by the property `dcterms:conformsTo`. Only a standard from the following list of fragment selectors <em title="MUST in RFC 2119 context" class="rfc2119">MUST</em> be used: https://www.w3.org/TR/annotation-model/#h-fragment-selector .
 
 ### Reference Part with Single Identifier
 The `iirds:FragmentSelector` refers to a single identifier in a file. 

--- a/sections/structure/rdfsschemaandiris.md
+++ b/sections/structure/rdfsschemaandiris.md
@@ -1,17 +1,20 @@
 
-# The iiRDS RDF Schema and Identifiers
+# The iiRDS RDF Schema and Namespaces
 
 iiRDS provides a vocabulary for documentation metadata as an RDF schema. The RDF schema contains the vocabulary and docking points for proprietary extensions. 
 
-The iiRDS vocabulary uses the following identifiers:
+The iiRDS vocabulary uses the following prefixes and namespaces:
 
-* *iiRDS Core:* http://iirds.tekom.de/iirds  
-* *iirds Domain:* http://iirds.tekom.de/iirds/domain
+| Part | Prefix | Namespace|
+|--|--|--|
+| Core | `iirds:` | http://iirds.tekom.de/iirds#
+| Domain extensions | | http://iirds.tekom.de/iirds/domain |
+| Domain: Machinery | `iirdsMach:` | http://iirds.tekom.de/iirds/domain/machinery# |
+| Domain: Software | `iirdsSft:` | http://iirds.tekom.de/iirds/domain/software# |
   
 <aside class="example" title="Examples of iiRDS IRIs">
 
-The identifier of the iiRDS topic class is `http://iirds.tekom.de/iirds#Topic`.
-   
-The identifier of an iiRDS circuit diagram is `http://iirds.tekom.de/iirds/domain/machinery#CircuitDiagram`. It is part of the iiRDS Machinery Domain.
+- The URI of the iiRDS topic class is `iirds:Topic` (`http://iirds.tekom.de/iirds#Topic`).
+- The URI of an iiRDS circuit diagram is `iirdsMach:CircuitDiagram` (`http://iirds.tekom.de/iirds/domain/machinery#CircuitDiagram`). It is part of the iiRDS Machinery Domain.
 
 </aside>


### PR DESCRIPTION
fix link to https://www.w3.org/TR/annotation-model/#h-fragment-selector as per https://github.com/iirds-consortium/specification/commit/6706292ec5b6c15e42d0f86ddf46ec7b13bab705
- the link should not be in square brackets
- the link was to an obsolete anchor, `#h-fragment-selector` is the up to date anchor

Sorry, this PR also mixes https://github.com/iirds-consortium/specification/pull/2, in the future I'll be more careful to create separate branches for each PR.